### PR TITLE
pushトリガーでvsceをビルドする

### DIFF
--- a/.github/workflows/vsce_package.yml
+++ b/.github/workflows/vsce_package.yml
@@ -1,0 +1,38 @@
+name: make vsce package
+
+env:
+  name: simple-text-refine
+
+on: [push, workflow_dispatch]
+
+jobs:
+  make-vsce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # mainブランチ以外は、package.json中のversionにコミットハッシュをappendする、--pre-releaseオプションを付ける
+      - name: Build dev
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          sed -i -e 's/"version": "\(.*\)"/"version": "\1+${{ github.sha }}"/' package.json
+          npm ci
+          npx vsce package --pre-release -o ${{ env.name }}-${VERSION}+${{ github.sha }}.vsix
+
+      # mainブランチ場合は、そのままpackage
+      - name: Build main
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          npm ci
+          npx vsce package
+
+      # 保存 (VSCode market placeに自動アップロードはいったんしない)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.name }}
+          path: "*.vsix"


### PR DESCRIPTION
- #8 
- とりあえず常にビルドする代わりに、バージョン表記にコミットハッシュを付けて正式版ではないことが分かるように
- devブランチでバージョンを上げたりして行けばよい
  - その場合、tagはいちいちつけなくてもgit的には大丈夫 (バージョンが追える) と思うが、GitHub Releaseを使うならtagがいるのかな…。rcはtag不要で本番リリース (mainにマージ) はtag付けてreleaseも置いて、という感じか

![image](https://github.com/yasuraok/SimpleTextRefine/assets/11373792/f2a1ad1a-637f-427a-9ee7-0c87a10a3d1e)
