### PR TITLE
WIP: LLM結果表示に関する操作改善

### DIFF
--- a/prg/extension.js
+++ b/prg/extension.js
@@ -64,13 +64,19 @@ async function setupParam(uri){
     return {settingPromptPath, apiKey, model, provider}
 }
 
+/**
+ * @param {vscode.Uri} uri
+ */
 function makeCachePath(uri){
     const wf = vscode.workspace.workspaceFolders
     if(!wf){
         throw new Error('Error: workspace is not selected.')
     }
-    const relPath = vscode.workspace.asRelativePath(uri)
-    const cachePath = vscode.Uri.joinPath(wf[0].uri, '.vscode', EXT_NAME, 'cache', relPath)
+    const cacheRoot = vscode.Uri.joinPath(wf[0].uri, '.vscode', EXT_NAME, 'cache')
+    if(uri.fsPath.startsWith(cacheRoot.fsPath)){
+        throw new Error('Error: this file might be LLM response cache. Please select your own file.')
+    }
+    const cachePath = vscode.Uri.joinPath(cacheRoot, vscode.workspace.asRelativePath(uri))
     // mkdir
     vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(cachePath, '..'))
     return cachePath


### PR DESCRIPTION
- [x] #29 
- [x] キャッシュファイルからLLM応答しようとすると失敗するように refs #28 
- ~~diff表示中のLLM応答ファイルが編集されていると次回のLLM応答時に表示更新されないのを回避する~~ 後回し