### PR TITLE
Avoid setting the same version between dev & main

### DIFF
--- a/.github/workflows/vsce_package.yml
+++ b/.github/workflows/vsce_package.yml
@@ -59,11 +59,15 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      # devブランチ場合は、versionはそのままでpre-releaseだけつける
-      # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+      # - devブランチ場合は、versionはそのままでpre-releaseだけつける
+      #   https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+      # - mainブランチがリリースされる際に↓のようにバージョンを上げるコミットが積まれているので
+      #   それをdevにマージしてからバージョン操作を始める
       - name: Build dev (pre-release)
         if: github.ref == 'refs/heads/dev'
         run: |
+          git merge --no-ff origin/main -m "Merge branch 'main' into dev [skip ci]"
+
           VERSION=$(npm version ${{ env.increment }} -m "%s ${{ env.skip_ci}}")
           PACKAGE_NAME="${{ env.name }}-${VERSION}+pre-release"
           npx vsce package --pre-release -o "${PACKAGE_NAME}.vsix"


### PR DESCRIPTION
GitHub Actionのnpm versionのincrementとvsce publishをお願いしているが、従来のコードではmainにマージした際にincrementされたnpm versionをdevが知らないままで、次にfeature -> devのマージをした際に同じversionが採番され、pre-release版の公開に失敗していた。事前に逆 (?) マージをしておく。